### PR TITLE
Remove 'apps' key.

### DIFF
--- a/reflect.config.json
+++ b/reflect.config.json
@@ -1,8 +1,3 @@
 {
-  "server": "reflect/index.ts",
-  "apps": {
-    "default": {
-      "appID": "loluf17a"
-    }
-  }
+  "server": "reflect/index.ts"
 }


### PR DESCRIPTION
Ah, despite what our docs say, you can't check in this key if you intend to publish the example as oss. Because people won't be able to access that app.

I'll think about what the right solution to this is on our side.